### PR TITLE
fix: databases function called with empty seq in firefox

### DIFF
--- a/src/indexed/db/impl/factory.cljs
+++ b/src/indexed/db/impl/factory.cljs
@@ -21,12 +21,16 @@
     (.cmp factory a b))
   (databases
     [_ fn-1]
-    (let [p (.databases factory)]
-      (-> p
-          (.then (fn [result]
-                   (cond-> result
-                     (array? result) (->> array-seq (map dict->map))
-                     :always         (fn-1))))))))
+    (if (type (.-databases factory))
+      (let [p (.databases factory)]
+        (-> p
+            (.then (fn [result]
+                     (cond-> result
+                       (array? result) (->> array-seq (map dict->map))
+                       :always         (fn-1))))))
+      (fn-1 '()))))
+
+(type (.-databases js/indexedDB))
 
 (defn factory?
   [x]


### PR DESCRIPTION
IDBFactory.databases does not exist in Firefox.

This PR causes the callback to be called with an empty sequence. This results in a failing test in Firefox, but that is a useful failure to report. 