### PR TITLE
chore: remove fdefs from db namespace

### DIFF
--- a/src/indexed/db.cljs
+++ b/src/indexed/db.cljs
@@ -1,12 +1,10 @@
 (ns indexed.db
-  (:require [cljs.spec.alpha :as s]
-            [indexed.db.impl.cursor :as cursor]
+  (:require [indexed.db.impl.cursor :as cursor]
             [indexed.db.impl.database :as database]
             [indexed.db.impl.events :as events]
             [indexed.db.impl.factory :as factory]
             [indexed.db.impl.key-range :as key-range]
             [indexed.db.impl.request :as request]
-            [indexed.db.spec :as db.spec]
             [indexed.db.impl.store :as store]
             [indexed.db.impl.transaction :as transaction]
             [indexed.db.impl.protocols :as impl])
@@ -19,19 +17,11 @@
   [x]
   (factory/factory? x))
 
-(s/fdef factory?
-  :args (s/cat :x any?)
-  :ret  boolean?)
-
 (defn create-factory
   "Return an implementation of the IDBFactory protocol backed by
    the global indexedDB object"
   []
   (factory/create-factory))
-
-(s/fdef create-factory
-  :args (s/cat)
-  :ret  ::db.spec/factory)
 
 (defn open
   "Return an IDBRequest whose result is a native IDBDatabase object.
@@ -62,12 +52,6 @@
   ([name]
    (factory/open name)))
 
-(s/fdef open
-  :args (s/alt :unary   (s/cat :name ::db.spec/name)
-               :binary  (s/cat :name ::db.spec/name :version ::db.spec/version)
-               :trinary (s/cat :factory ::db.spec/factory :name ::db.spec/name :version ::db.spec/version))
-  :ret  ::db.spec/open-db-request)
-
 (defn delete-database
   "Request the deletion of a database by name.
    
@@ -76,11 +60,6 @@
    (factory/delete-database factory name))
   ([name]
    (factory/delete-database name)))
-
-(s/fdef delete-database
-  :args (s/alt :unary  (s/cat :name ::db.spec/name)
-               :binary (s/cat :factory ::db.spec/factory :name ::db.spec/name))
-  :ret  ::db.spec/open-db-request)
 
 (defn cmp
   "Compares two values as keys to determine equality and ordering for IndexedDB operations,
@@ -96,11 +75,6 @@
   ([a b]
    (factory/cmp a b)))
 
-(s/fdef cmp
-  :args (s/alt :binary  (s/cat :a any? :b any?)
-               :trinary (s/cat :factory ::db.spec/factory :a any? :b any?))
-  :ret  boolean?)
-
 (defn databases
   "Calls the given function with an error or a sequence of all
    available databases, including their names and versions"
@@ -110,11 +84,6 @@
   ([fn-1]
    (factory/databases fn-1)))
 
-(s/fdef databases
-  :args (s/alt :unary  (s/cat :fn-1 ::db.spec/databases-callback)
-               :binary (s/cat :factory ::db.spec/factory :fn-1 ::db.spec/databases-callback))
-  :ret  ::db.spec/factory)
-
 ;;; IDBDatabase
 
 (defn database?
@@ -122,38 +91,22 @@
   [x]
   (database/database? x))
 
-(s/fdef database?
-  :args (s/cat :x any?)
-  :ret  boolean?)
-
 (defn db
   "Returns an implementation of the IDBDatabase protocol that is associated
    with `belongs-to-database` (presumably an IDBTransaction implementation)"
   [belongs-to-database]
   (database/db belongs-to-database))
 
-(s/fdef db
-  :args (s/cat ::belongs-to-database ::db.spec/belongs-to-database)
-  :ret  ::db.spec/database)
-
 (defn get-database
   "An alias for the [[indexed.db/db]] function"
   [belongs-to-database]
   (db belongs-to-database))
-
-(s/fdef get-database
-  :args (s/cat ::belongs-to-database ::db.spec/belongs-to-database)
-  :ret  ::db.spec/database)
 
 (defn create-database
   "A factory function for creating an implementation of the IDBDatabase protocol
    from a native js/IDBDatabase"
   [js-idb]
   (database/create-database js-idb))
-
-(s/fdef create-database
-  :args (s/cat :js-idb ::db.spec/js-idb)
-  :ret  ::db.spec/database)
 
 (defn close
   "Returns immediately and closes the connection in a separate thread.
@@ -165,19 +118,11 @@
   [db]
   (database/close db))
 
-(s/fdef close
-  :args (s/cat :db ::db.spec/database)
-  :ret  any?)
-
 (defn delete-object-store
   "Destroys the object store with the given name in the connected database, along with
    any indexes that reference it."
   [db name]
   (database/delete-object-store db name))
-
-(s/fdef delete-object-store
-  :args (s/cat :db ::db.spec/database :name ::db.spec/name)
-  :ret  ::db.spec/database)
 
 (defn object-store-names
   "Returns a sequence of object store names from the given database or transaction"
@@ -186,18 +131,10 @@
     (satisfies? impl/IDBTransaction x) (db)
     :always (database/object-store-names)))
 
-(s/fdef object-store-names
-  :args (s/cat :x (s/or :transaction ::db.spec/transaction :database ::db.spec/database))
-  :ret  ::db.spec/object-store-names)
-
 (defn version
   "Returns an integer version of the connected database"
   [db]
   (database/version db))
-
-(s/fdef version
-  :args (s/cat :db ::db.spec/database)
-  :ret  ::db.spec/version)
 
 (defn transaction
   "Immediately returns an implementation of the IDBTransaction protocol.
@@ -210,12 +147,6 @@
   ([db store-names]
    (database/transaction db store-names)))
 
-(s/fdef transaction
-  :args (s/alt :binary     (s/cat :db ::db.spec/database :store-names ::db.spec/object-store-names)
-               :trinary    (s/cat :db ::db.spec/database :store-names ::db.spec/object-store-names :mode ::db.spec/mode)
-               :quaternary (s/cat :db ::db.spec/database :store-names ::db.spec/object-store-names :mode ::db.spec/mode :options ::db.spec/transaction-options))
-  :ret  ::db.spec/transaction)
-
 ;;; IDBCursor/IDBCursorWithValue
 
 (defn cursor?
@@ -223,19 +154,11 @@
   [x]
   (cursor/cursor? x))
 
-(s/fdef cursor?
-  :args (s/cat :x any?)
-  :ret  boolean?)
-
 (defn create-cursor
   "A factory function for creating an implementation of the IDBCursor protocol
    from a native js/IDBCursor"
   [js-cursor]
   (cursor/create-cursor js-cursor))
-
-(s/fdef create-cursor
-  :args (s/cat :js-cursor ::db.spec/js-cursor)
-  :ret  ::db.spec/cursor)
 
 (defn direction
   "Returns the direction of traversal of the cursor. See [[indexed.db/open-cursor]]
@@ -243,18 +166,10 @@
   [cursor]
   (cursor/direction cursor))
 
-(s/fdef direction
-  :args (s/cat :cursor ::db.spec/cursor)
-  :ret  ::db.spec/direction)
-
 (defn key
   "Returns the key for the record at the cursor's position"
   [cursor]
   (cursor/key cursor))
-
-(s/fdef key
-  :args (s/cat :cursor ::db.spec/cursor)
-  :ret  any?)
 
 (defn primary-key
   "Interface returns the cursor's current effective key. If the cursor is currently being iterated
@@ -262,18 +177,10 @@
   [cursor]
   (cursor/primary-key cursor))
 
-(s/fdef primary-key
-  :args (s/cat :cursor ::db.spec/cursor)
-  :ret  any?)
-
 (defn advance
   "Sets the number of times a cursor should move its position forward"
   [cursor count]
   (cursor/advance cursor count))
-
-(s/fdef advance
-  :args (s/cat :cursor ::db.spec/cursor :count pos-int?)
-  :ret  nil?)
 
 (defn continue
   "Advances the cursor to the next position along its direction, to the item whose key matches
@@ -283,11 +190,6 @@
   ([cursor]
    (continue cursor nil)))
 
-(s/fdef continue
-  :args (s/alt :unary  (s/cat :cursor ::db.spec/cursor)
-               :binary (s/cat :cursor ::db.spec/cursor :k any?))
-  :ret  nil?)
-
 (defn continue-primary-key
   "Advances the cursor to the item whose key matches the key parameter as well as whose primary key
    matches the primary key parameter.
@@ -295,10 +197,6 @@
    A typical use case, is to resume the iteration where a previous cursor has been closed, without having to compare the keys one by one."
   [cursor k primary-key]
   (cursor/continue-primary-key cursor k primary-key))
-
-(s/fdef continue-primary-key
-  :args (s/cat :cursor ::db.spec/cursor :k any? :primary-key any?)
-  :ret  nil?)
 
 (defn update
   "Returns an implementation of the IDBRequest protocol, and, in a separate thread, updates the value
@@ -311,18 +209,10 @@
   [cursor value]
   (cursor/update cursor value))
 
-(s/fdef update
-  :args (s/cat :cursor ::db.spec/cursor :value any?)
-  :ret  ::db.spec/request)
-
 (defn cursor-with-value?
   "Returns true if the given value satisfies the IDBCursorWithValue protocol"
   [x]
   (cursor/cursor-with-value? x))
-
-(s/fdef cursor-with-value?
-  :args (s/cat :x any?)
-  :ret boolean?)
 
 (defn create-cursor-with-value
   "A factory function for creating an implementation of the IDBCursorWithValue protocol
@@ -330,18 +220,10 @@
   [js-cursor-with-value]
   (cursor/create-cursor-with-value js-cursor-with-value))
 
-(s/fdef create-cursor-with-value
-  :args (s/cat :js-cursor-with-value ::db.spec/js-cursor-with-value)
-  :ret  ::db.spec/cursor-with-value)
-
 (defn value
   "Returns the value of the current cursor, whatever that is"
   [cursor-with-value]
   (cursor/value cursor-with-value))
-
-(s/fdef value
-  :args (s/cat :cursor-with-value ::db.spec/cursor-with-value)
-  :ret  any?)
 
 ;;; IDBRequest
 
@@ -350,19 +232,11 @@
   [x]
   (request/request? x))
 
-(s/fdef request?
-  :args (s/cat :x any?)
-  :ret  boolean?)
-
 (defn create-request
   "A factory function for creating an implementation of the IDBRequest protocol
    from a native js/IDBRequest"
   [js-request]
   (request/create-request js-request))
-
-(s/fdef create-request
-  :args (s/cat :js-request ::db.spec/js-request)
-  :ret  ::db.spec/request)
 
 (defn error
   "If a type stores an error for failed operations, this function
@@ -370,27 +244,15 @@
   [has-errors]
   (impl/error has-errors))
 
-(s/fdef error
-  :args (s/cat :has-errors ::db.spec/has-errors)
-  :ret  (s/nilable ::db.spec/dom-exception))
-
 (defn result
   "Returns the result of the request"
   [db-request]
   (request/result db-request))
 
-(s/fdef result
-  :args (s/cat :db-request ::db.spec/request)
-  :ret  any?)
-
 (defn ready-state
   "Returns the state of the request"
   [db-request]
   (request/ready-state db-request))
-
-(s/fdef ready-state
-  :args (s/cat :db-request ::db.spec/request)
-  :ret  ::db.spec/ready-state)
 
 ;;; Events
 
@@ -398,10 +260,6 @@
   "Returns true if the given value satisfies the IDBVersionChangeEvent protocol"
   [x]
   (events/version-change-event? x))
-
-(s/fdef version-change-event?
-  :args (s/cat :x any?)
-  :ret  boolean?)
 
 (defn create-version-change-event
   "A factory function for creating an implementation of the IDBVersionChangeEvent protocol
@@ -422,27 +280,15 @@
   [js-event]
   (events/create-version-change-event js-event))
 
-(s/fdef create-version-change-event
-  :args (s/cat :js-event ::db.spec/js-version-change-event)
-  :ret  ::db.spec/version-change-event)
-
 (defn new-version
   "Returns the new version number of the database"
   [version-change-event]
   (events/new-version version-change-event))
 
-(s/fdef new-version
-  :args (s/cat :version-change-event ::db.spec/version-change-event)
-  :ret  ::db.spec/version)
-
 (defn old-version
   "Returns the old version number of the database"
   [version-change-event]
   (events/old-version version-change-event))
-
-(s/fdef old-version
-  :args (s/cat :version-change-event ::db.spec/version-change-event)
-  :ret  ::db.spec/version)
 
 (defn get-request
   "Return the IDBRequest that `belongs-to-request` belongs to. This is presumably
@@ -451,18 +297,10 @@
   (create-request
    (impl/idb-request belongs-to-request)))
 
-(s/fdef get-request
-  :args (s/cat ::belongs-to-request ::db.spec/belongs-to-request)
-  :ret  ::db.spec/request)
-
 (defn event-target?
   "Returns true if the given value satisfies the EventTarget protocol"
   [x]
   (events/event-target? x))
-
-(s/fdef event-target?
-  :args (s/cat :x any?)
-  :ret  boolean?)
 
 (defn on
   "A simple wrapper around the native addEventListener function.
@@ -473,11 +311,6 @@
   ([event-target type listener options]
    (events/on event-target type listener options)))
 
-(s/fdef on
-  :args (s/alt :trinary    (s/cat :event-target ::db.spec/event-target :type string? :listener fn?)
-               :quaternary (s/cat :event-target ::db.spec/event-target :type string? :listener fn? :options (s/or :options map? :use-capture? boolean?)))
-  :ret  ::db.spec/event-target)
-
 (defn off
   "A simple wrapper around the native removeEventListener function.
    
@@ -486,11 +319,6 @@
    (events/off event-target type listener))
   ([event-target type listener options]
    (events/off event-target type listener options)))
-
-(s/fdef off
-  :args (s/alt :trinary    (s/cat :event-target ::db.spec/event-target :type string? :listener fn?)
-               :quaternary (s/cat :event-target ::db.spec/event-target :type string? :listener fn? :options (s/or :options map? :use-capture? boolean?)))
-  :ret  ::db.spec/event-target)
 
 ;;; IDBKeyRange
 
@@ -504,45 +332,25 @@
   [key-range k]
   (key-range/includes key-range k))
 
-(s/fdef includes
-  :args (s/cat :key-range ::db.spec/key-range :k any?)
-  :ret  boolean?)
-
 (defn lower
   "Returns the lower bound of the key range"
   [key-range]
   (key-range/lower key-range))
-
-(s/fdef lower
-  :args (s/cat :key-range ::db.spec/key-range)
-  :ret  any?)
 
 (defn upper
   "Returns the upper bound of the key range"
   [key-range]
   (key-range/upper key-range))
 
-(s/fdef upper
-  :args (s/cat :key-range ::db.spec/key-range)
-  :ret  any?)
-
 (defn lower-open?
   "Returns false if the lower-bound value is included in the key range"
   [key-range]
   (key-range/lower-open? key-range))
 
-(s/fdef lower-open?
-  :args (s/cat :key-range ::db.spec/key-range)
-  :ret  boolean?)
-
 (defn upper-open?
   "Returns false if the upper-bound value is included in the key range"
   [key-range]
   (key-range/upper-open? key-range))
-
-(s/fdef upper-open?
-  :args (s/cat :key-range ::db.spec/key-range)
-  :ret  boolean?)
 
 (defn bound
   "Creates a new key range with the specified upper and lower bounds. The bounds can be open
@@ -556,20 +364,10 @@
   ([lower upper]
    (key-range/bound lower upper)))
 
-(s/fdef bound
-  :args (s/alt :binary     (s/cat :lower any? :upper any?)
-               :trinary    (s/cat :lower any? :upper any? :lower-open? boolean?)
-               :quaternary (s/cat :lower any? :upper any? :lower-open? boolean? :upper-open? boolean?))
-  :ret  ::db.spec/key-range)
-
 (defn only
   "Creates a new key range containing a single value"
   [value]
   (key-range/only value))
-
-(s/fdef only
-  :args (s/cat :value any?)
-  :ret  ::db.spec/key-range)
 
 (defn lower-bound
   "Creates a new key range with only a lower bound.
@@ -580,11 +378,6 @@
   ([lower]
    (key-range/lower-bound lower)))
 
-(s/fdef lower-bound
-  :args (s/alt :unary  (s/cat :lower any?)
-               :binary (s/cat :lower any? :open? boolean?))
-  :ret  ::db.spec/key-range)
-
 (defn upper-bound
   "Creates a new upper-bound key range.
    
@@ -594,11 +387,6 @@
   ([upper]
    (key-range/upper-bound upper)))
 
-(s/fdef upper-bound
-  :args (s/alt :unary  (s/cat :lower any?)
-               :binary (s/cat :lower any? :open? boolean?))
-  :ret  ::db.spec/key-range)
-
 ;;; IDBTransaction
 
 (defn transaction?
@@ -606,19 +394,11 @@
   [x]
   (transaction/transaction? x))
 
-(s/fdef transaction?
-  :args (s/cat :x any?)
-  :ret  boolean?)
-
 (defn create-transaction
   "A factory function for creating an implementation of the IDBTransaction protocol
    from a native js/IDBTransaction"
   [js-idb-transaction]
   (transaction/create-transaction js-idb-transaction))
-
-(s/fdef create-transaction
-  :args (s/cat :js-idb-transaction ::db.spec/js-transaction)
-  :ret  ::db.spec/transaction)
 
 (defn get-transaction
   "Return the IDBTransaction that `belongs-to-txn` belongs to. This is presumably
@@ -626,36 +406,20 @@
   [belongs-to-txn]
   (transaction/transaction belongs-to-txn))
 
-(s/fdef get-transaction
-  :args (s/cat :belongs-to-txn ::db.spec/belongs-to-transaction)
-  :ret  (s/nilable ::db.spec/transaction))
-
 (defn durability
   "Returns the durability hint the transaction was created with"
   [txn]
   (transaction/durability txn))
-
-(s/fdef durability
-  :args (s/cat :txn ::db.spec/transaction)
-  :ret  ::db.spec/durability)
 
 (defn mode
   "Returns the current mode for accessing the data in the object stores in the scope of the transaction"
   [txn]
   (transaction/mode txn))
 
-(s/fdef mode
-  :args (s/cat :txn ::db.spec/transaction)
-  :ret  ::db.spec/mode)
-
 (defn abort
   "Rolls back all the changes to objects in the database associated with this transaction"
   [txn]
   (transaction/abort txn))
-
-(s/fdef abort
-  :args (s/cat :txn ::db.spec/transaction)
-  :ret  nil?)
 
 (defn commit
   "Commits the transaction if it is called on an active transaction.
@@ -665,20 +429,12 @@
   [txn]
   (transaction/commit txn))
 
-(s/fdef commit
-  :args (s/cat :txn ::db.spec/transaction)
-  :ret  nil?)
-
 ;;; IDBIndex/IDBObjectStore
 
 (defn key-path
   "Returns the key path of this object store"
   [store-or-index]
   (store/key-path store-or-index))
-
-(s/fdef key-path
-  :args (s/cat :store-or-index ::db.spec/readable-store)
-  :ret  ::db.spec/key-path)
 
 (defn count
   "Returns an implementation of the IDBRequest protocol, and, in a separate thread,
@@ -690,11 +446,6 @@
   ([store-or-index]
    (store/count store-or-index)))
 
-(s/fdef count
-  :args (s/alt :unary  (s/cat :store-or-index ::db.spec/readable-store)
-               :binary (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query))
-  :ret  ::db.spec/request)
-
 (defn get
   "Returns an implementation of the IDBRequest protocol, and, in a separate thread, finds either the value in the referenced
    object store or index that corresponds to the given key or the first corresponding value, if key is set to an IDBKeyRange.
@@ -703,10 +454,6 @@
   [store-or-index k]
   (store/get store-or-index k))
 
-(s/fdef get
-  :args (s/cat :store-or-index ::db.spec/readable-store :k ::db.spec/query)
-  :ret  ::db.spec/request)
-
 (defn get-key
   "Returns an implementation of the IDBRequest protocol, and, in a separate thread, finds either the primary key
    that corresponds to the given key in this index (or object store) or the first corresponding primary key, if key is set to an IDBKeyRange.
@@ -714,10 +461,6 @@
    If a primary key is found, it is set as the result of the request object. Note that this doesn't return the whole record as get does."
   [store-or-index k]
   (store/get-key store-or-index k))
-
-(s/fdef get-key
-  :args (s/cat :store-or-index ::db.spec/readable-store :k ::db.spec/query)
-  :ret  ::db.spec/request)
 
 (defn get-all
   "Retrieves all objects that are inside the index or store. Returns an IDBRequest containing
@@ -729,12 +472,6 @@
   ([store-or-index]
    (store/get-all store-or-index)))
 
-(s/fdef get-all
-  :args (s/alt :unary   (s/cat :store-or-index ::db.spec/readable-store)
-               :binary  (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query)
-               :trinary (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query :count pos-int?))
-  :ret  ::db.spec/request)
-
 (defn get-all-keys
   "Asynchronously retrieves the primary keys of all objects inside the index or store,
    setting them as the result of the request"
@@ -744,12 +481,6 @@
    (store/get-all-keys store-or-index query))
   ([store-or-index]
    (store/get-all-keys store-or-index)))
-
-(s/fdef get-all-keys
-  :args (s/alt :unary   (s/cat :store-or-index ::db.spec/readable-store)
-               :binary  (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query)
-               :trinary (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query :count pos-int?))
-  :ret  ::db.spec/request)
 
 (defn open-cursor
   "Returns an IDBRequest, and, in a separate thread, creates a cursor over the specified key range.
@@ -778,12 +509,6 @@
   ([store-or-index]
    (store/open-cursor store-or-index)))
 
-(s/fdef open-cursor
-  :args (s/alt :unary   (s/cat :store-or-index ::db.spec/readable-store)
-               :binary  (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query)
-               :trinary (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query :direction ::db.spec/direction))
-  :ret  ::db.spec/request)
-
 (defn open-key-cursor
   "Returns an IDBRequest, and, in a separate thread, creates a cursor over the specified key range, as arranged by this index.
    
@@ -799,20 +524,10 @@
   ([store-or-index]
    (store/open-key-cursor store-or-index)))
 
-(s/fdef open-key-cursor
-  :args (s/alt :unary   (s/cat :store-or-index ::db.spec/readable-store)
-               :binary  (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query)
-               :trinary (s/cat :store-or-index ::db.spec/readable-store :query ::db.spec/query :direction ::db.spec/direction))
-  :ret  ::db.spec/request)
-
 (defn index?
   "Returns true if the given value satisfies the IDBIndex protocol"
   [x]
   (store/index? x))
-
-(s/fdef index?
-  :args (s/cat :x any?)
-  :ret  boolean?)
 
 (defn auto-locale?
   "Returns a boolean value indicating whether the index had a locale value of auto specified upon its creation.
@@ -821,10 +536,6 @@
   [index]
   (store/auto-locale? index))
 
-(s/fdef auto-locale?
-  :args (s/cat :index ::db.spec/index)
-  :ret  boolean?)
-
 (defn locale
   "Returns the locale of the index (for example en-US, or pl) if it had a locale value specified upon its creation.
    
@@ -832,18 +543,10 @@
   [index]
   (store/locale index))
 
-(s/fdef locale
-  :args (s/cat :index ::db.spec/index)
-  :ret  string?)
-
 (defn get-object-store
   "Returns the object store the index belongs to"
   [index]
   (store/get-object-store index))
-
-(s/fdef get-object-store
-  :args (s/cat :index ::db.spec/index)
-  :ret  ::db.spec/store)
 
 (defn multi-entry?
   "Returns a boolean value that affects how the index behaves when the result of evaluating the index's
@@ -851,36 +554,20 @@
   [index]
   (store/multi-entry? index))
 
-(s/fdef multi-entry?
-  :args (s/cat :index ::db.spec/index)
-  :ret  boolean?)
-
 (defn unique?
   "Returns a boolean that states whether the index allows duplicate keys"
   [index]
   (store/unique? index))
-
-(s/fdef index
-  :args (s/cat :index ::db.spec/index)
-  :ret  boolean?)
 
 (defn store?
   "Returns true if the given value satisfies the IDBObjectStore protocol"
   [x]
   (store/store? x))
 
-(s/fdef store?
-  :args (s/cat :x any?)
-  :ret  boolean?)
-
 (defn index-names
   "Returns a sequence of the names of indexes on objects in this object store"
   [store]
   (store/index-names store))
-
-(s/fdef index-names
-  :args (s/cat :store ::db.spec/store)
-  :ret  (s/coll-of string?))
 
 (defn auto-increment?
   "Returns the value of the auto increment flag for this object store.
@@ -888,10 +575,6 @@
    Note that every object store has its own separate auto increment counter"
   [store]
   (store/auto-increment? store))
-
-(s/fdef auto-increment?
-  :args (s/cat :store ::db.spec/store)
-  :ret  boolean?)
 
 (defn add
   "Returns an implementation of the IDBRequest protocol, and, in a separate thread, creates a
@@ -905,21 +588,12 @@
   ([store value]
    (store/add store value)))
 
-(s/fdef add
-  :args (s/alt :binary  (s/cat :store ::db.spec/store :value any?)
-               :trinary (s/cat :store ::db.spec/store :value any? :k any?))
-  :ret  ::db.spec/request)
-
 (defn clear
   "Creates and immediately returns an IDBRequest, and clears this object store in a separate thread.
    
    This is for deleting all the current data out of an object store"
   [store]
   (store/clear store))
-
-(s/fdef clear
-  :args (s/cat :store ::db.spec/store)
-  :ret  ::db.spec/request)
 
 (defn create-index
   "Creates and returns an implementation of the IDBIndex protocol in the connected database.
@@ -932,11 +606,6 @@
   ([store index-name key-path]
    (store/create-index store index-name key-path)))
 
-(s/fdef create-index
-  :args (s/alt :trinary    (s/cat :store ::db.spec/store :index-name string? :key-path ::db.spec/key-path)
-               :quaternary (s/cat :store ::db.spec/store :index-name string? :key-path ::db.spec/key-path :object-parameters ::db.spec/index-options))
-  :ret  ::db.spec/index)
-
 (defn delete-index
   "Destroys the index with the specified name in the connected database, used during a version upgrade
    
@@ -944,19 +613,11 @@
   [store index-name]
   (store/delete-index store index-name))
 
-(s/fdef delete-index
-  :args (s/cat :store ::db.spec/store :index-name string?)
-  :ret  nil?)
-
 (defn index
   "Opens a named index in the current object store, after which it can be used to, for example,
    return a series of records sorted by that index using a cursor"
   [store index-name]
   (store/index store index-name))
-
-(s/fdef index
-  :args (s/cat :store ::db.spec/store :index-name string?)
-  :ret  ::db.spec/index)
 
 (defn put
   "Updates a given record in a database, or inserts a new record if the given item does not already exist"
@@ -964,11 +625,6 @@
    (store/put store item))
   ([store item k]
    (store/put store item k)))
-
-(s/fdef put
-  :args (s/alt :binary  (s/cat :store ::db.spec/store :item any?)
-               :trinary (s/cat :store ::db.spec/store :item any? :k any?))
-  :ret  ::db.spec/request)
 
 (defn delete
   "When given an IDBObjectStore and a key, returns an IDBRequest,
@@ -982,11 +638,6 @@
   ([store k]
    (store/delete store k)))
 
-(s/fdef delete
-  :args (s/alt :store  (s/cat :store ::db.spec/store :k any?)
-               :cursor (s/cat :cursor ::db.spec/cursor))
-  :ret  ::db.spec/request)
-
 (defn create-object-store
   "When called with an IDBDatabase, creates and returns a new IDBObjectStore.
    
@@ -999,12 +650,6 @@
   ([js-idb-store]
    (store/create-object-store js-idb-store)))
 
-(s/fdef create-object-store
-  :args (s/alt :database-with-options (s/cat :db ::db.spec/database :name ::db.spec/name :options ::db.spec/store-options)
-               :database-no-options   (s/cat :db ::db.spec/database :name ::db.spec/name)
-               :factory               (s/cat :js-idb-store ::db.spec/js-store))
-  :ret  ::db.spec/store)
-
 (defn object-store
   "When called with a transaction and object store name, returns an object store that
    has already been added to the scope of this transaction.
@@ -1014,11 +659,6 @@
    (transaction/object-store txn name))
   ([index]
    (get-object-store index)))
-
-(s/fdef object-store
-  :args (s/alt :transaction (s/cat :txn ::db.spec/transaction :name ::db.spec/name)
-               :index       (s/cat :index ::db.spec/index))
-  :ret  ::db.spec/store)
 
 (defn source
   "In the case of a cursor, returns the IDBObjectStore or IDBIndex that the cursor is iterating over.
@@ -1030,7 +670,3 @@
       (instance? js/IDBObjectStore src) (create-object-store src)
       (instance? js/IDBIndex src) (store/create-index* src)
       :else nil)))
-
-(s/fdef source
-  :args (s/cat :x (s/or :cursor ::db.spec/cursor :request ::db.spec/request))
-  :ret  (s/nilable (s/or :index ::db.spec/index :store ::db.spec/store)))


### PR DESCRIPTION
Removes fdefs from the `db` namespace per this [feedback](https://www.reddit.com/r/Clojure/comments/tzaois/indexeddb_its_just_indexeddb_for_clojurescript/i3yfo4x/?utm_source=reddit&utm_medium=web2x&context=3) 🕊️ 